### PR TITLE
Fixed appId for all OS's

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,7 +19,7 @@ files:
   - '!scripts{/*}'
   - '!test{/*}'
 mac:
-  appId: bet.decent.mac
+  appId: bet.decent.wallet.mac
   icon: ./icon.icns
   category: public.app-category.finance
   type: distribution
@@ -37,13 +37,13 @@ dmg:
       type: link
       path: /Applications
 linux:
-  appId: bet.decent.linux
+  appId: bet.decent.wallet.linux
   icon: ./icons/
   target:
     - AppImage
   category: Finance
 win:
-  appId: bet.decent.windows
+  appId: bet.decent.wallet.windows
   icon: ./icon.ico
   target:
     - target: nsis


### PR DESCRIPTION
Set appId's per OS:
- mac: `bet.decent.wallet.mac`
- linux: `bet.decent.wallet.linux`
- windows: `bet.decent.wallet.windows`